### PR TITLE
Refactor: Add test launcher dependency

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.mockk)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    //noinspection UseTomlInstead
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     compileOnly(libs.firebase.google.services)
 

--- a/androidAppLite/build.gradle.kts
+++ b/androidAppLite/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.mockk)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    //noinspection UseTomlInstead
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     debugRuntimeOnly(libs.androidx.compose.ui.test.manifest)
     debugRuntimeOnly(libs.androidx.compose.ui.tooling.android)


### PR DESCRIPTION
* Add `junit-platform-launcher` as a test runtime dependency in both `androidApp` and `androidAppLite` modules.